### PR TITLE
stream: handle empty track list

### DIFF
--- a/internal/stream/player.go
+++ b/internal/stream/player.go
@@ -85,6 +85,12 @@ func (s *Station) AddListener() (chan []byte, func()) {
 // loop continuously plays tracks and broadcasts to listeners.
 func (s *Station) loop() {
 	for {
+		// Если треков нет, подождать и продолжить цикл, чтобы избежать пустого CPU-цикла
+		if len(s.tracks) == 0 {
+			logrus.WithField("station", s.name).Warn("no tracks available")
+			time.Sleep(time.Second)
+			continue
+		}
 		for _, track := range s.tracks {
 			s.mu.Lock()
 			s.current = filepath.Base(track)


### PR DESCRIPTION
## Summary
- avoid busy loop when station has no tracks

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688bdb7ccc108325a4af9d7fe4b617bb