### PR TITLE
Добавлены тесты для сервера и плеера

### DIFF
--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -1,0 +1,116 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+	"x07-it/radiod/internal/config"
+	"x07-it/radiod/internal/stream"
+)
+
+// createTestPlayer создаёт Player с одной станцией и временным треком.
+func createTestPlayer(t *testing.T) (*stream.Player, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	track := filepath.Join(dir, "track.mp3")
+	content := []byte("test-audio")
+	if err := os.WriteFile(track, content, 0o644); err != nil {
+		t.Fatalf("write track: %v", err)
+	}
+	logrus.WithField("track", track).Info("создан временный трек")
+	cfg := config.Config{OutputBitrate: "320k", BufferSeconds: 0}
+	p := stream.NewPlayer(cfg)
+	p.AddStation("demo", []string{track})
+	return p, track, string(content)
+}
+
+// TestStationsEndpoint проверяет выдачу списка станций.
+func TestStationsEndpoint(t *testing.T) {
+	logrus.Info("тестируем /stations")
+	gin.SetMode(gin.TestMode)
+	p, _, _ := createTestPlayer(t)
+	r := SetupRouter(p)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/stations", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", w.Code)
+	}
+	expected := "[\"demo\"]"
+	if strings.TrimSpace(w.Body.String()) != expected {
+		t.Fatalf("unexpected body: %s", w.Body.String())
+	}
+}
+
+// TestNowPlayingEndpoint проверяет текущий трек станции.
+func TestNowPlayingEndpoint(t *testing.T) {
+	logrus.Info("тестируем /nowplaying")
+	gin.SetMode(gin.TestMode)
+	p, track, _ := createTestPlayer(t)
+	r := SetupRouter(p)
+	// Ожидаем установки NowPlaying.
+	st := p.Get("demo")
+	deadline := time.Now().Add(time.Second)
+	for st.NowPlaying() == "" {
+		if time.Now().After(deadline) {
+			t.Fatal("now playing not set")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	w := httptest.NewRecorder()
+	url := "/nowplaying/demo"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d", w.Code)
+	}
+	expected := fmt.Sprintf("{\"now\":\"%s\"}", filepath.Base(track))
+	if strings.TrimSpace(w.Body.String()) != expected {
+		t.Fatalf("body %s", w.Body.String())
+	}
+}
+
+// TestStreamEndpoint проверяет получение аудиоданных.
+func TestStreamEndpoint(t *testing.T) {
+	logrus.Info("тестируем /stream")
+	gin.SetMode(gin.TestMode)
+	p, _, content := createTestPlayer(t)
+	r := SetupRouter(p)
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/stream/demo", nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	buf := make([]byte, len(content))
+	if _, err := io.ReadFull(resp.Body, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(buf, []byte(content)) {
+		t.Fatalf("unexpected data: %q", buf)
+	}
+}

--- a/internal/stream/player_test.go
+++ b/internal/stream/player_test.go
@@ -1,0 +1,62 @@
+package stream
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"x07-it/radiod/internal/config"
+)
+
+// TestAddStation проверяет регистрацию станции.
+func TestAddStation(t *testing.T) {
+	logrus.Info("проверка AddStation")
+	dir := t.TempDir()
+	track := filepath.Join(dir, "a.mp3")
+	if err := os.WriteFile(track, []byte("aaa"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cfg := config.Config{OutputBitrate: "320k", BufferSeconds: 0}
+	p := NewPlayer(cfg)
+	p.AddStation("a", []string{track})
+	if p.Get("a") == nil {
+		t.Fatal("station not added")
+	}
+	names := p.StationNames()
+	if len(names) != 1 || names[0] != "a" {
+		t.Fatalf("unexpected names: %v", names)
+	}
+}
+
+// TestAddListener проверяет добавление и удаление слушателя.
+func TestAddListener(t *testing.T) {
+	logrus.Info("проверка AddListener")
+	st := &Station{name: "x", listeners: make(map[chan []byte]struct{})}
+	ch, remove := st.AddListener()
+	if len(st.listeners) != 1 {
+		t.Fatal("listener not stored")
+	}
+	if cap(ch) != 16 {
+		t.Fatalf("unexpected cap: %d", cap(ch))
+	}
+	remove()
+	if _, ok := <-ch; ok {
+		t.Fatal("channel not closed")
+	}
+}
+
+// TestBroadcastQueue проверяет порядок доставки данных через очередь.
+func TestBroadcastQueue(t *testing.T) {
+	logrus.Info("проверка очереди вещания")
+	st := &Station{name: "q", listeners: make(map[chan []byte]struct{})}
+	ch, _ := st.AddListener()
+	st.broadcast([]byte("one"))
+	st.broadcast([]byte("two"))
+	d1 := <-ch
+	d2 := <-ch
+	if !bytes.Equal(d1, []byte("one")) || !bytes.Equal(d2, []byte("two")) {
+		t.Fatalf("unexpected data: %q %q", d1, d2)
+	}
+}


### PR DESCRIPTION
## Summary
- тесты для эндпоинтов `/stations`, `/nowplaying` и `/stream`
- покрытие `AddStation`, `AddListener` и очереди в `stream.Player`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688bdb9e82f08325a54b2a4aecc2209e