### PR TITLE
Log listener connect/disconnect in stream handler

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -62,7 +62,24 @@ func SetupRouter(p *stream.Player) *gin.Engine {
 			return
 		}
 		ch, remove := st.AddListener()
-		defer remove()
+
+		// Логируем подключение слушателя для аудита и отладки.
+		remoteIP := c.ClientIP()
+		stationName := c.Param("station")
+		logrus.WithFields(logrus.Fields{
+			"remote":  remoteIP,
+			"station": stationName,
+		}).Info("listener connected")
+
+		defer func() {
+			remove()
+			// При отключении фиксируем событие с теми же данными.
+			logrus.WithFields(logrus.Fields{
+				"remote":  remoteIP,
+				"station": stationName,
+			}).Info("listener disconnected")
+		}()
+
 		c.Header("Content-Type", "audio/mpeg")
 		c.Status(200)
 		c.Stream(func(w io.Writer) bool {


### PR DESCRIPTION
## Summary
- log listener connections and disconnections in /stream/:station handler

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688bdd9b5f688325adf430cc265de3fc